### PR TITLE
Make snr field in Metadata struct optional

### DIFF
--- a/src/v3/mod.rs
+++ b/src/v3/mod.rs
@@ -107,6 +107,8 @@ pub struct Metadata {
     #[serde(default)]
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub gateway_ids: HashMap<String, String>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time: Option<DateTime<Utc>>,
     pub rssi: f64,
     pub channel_rssi: f64,

--- a/src/v3/mod.rs
+++ b/src/v3/mod.rs
@@ -110,7 +110,9 @@ pub struct Metadata {
     pub time: Option<DateTime<Utc>>,
     pub rssi: f64,
     pub channel_rssi: f64,
-    pub snr: f64,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snr: Option<f64>,
     pub uplink_token: String,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/test/v3/uplink2.json
+++ b/test/v3/uplink2.json
@@ -73,7 +73,6 @@
         "timestamp": 2683985228,
         "rssi": -131,
         "channel_rssi": -131,
-        "snr": -11.2,
         "location": {
           "latitude": 47.0,
           "longitude": 8.3,


### PR DESCRIPTION
I found another optional field in the wild: The `snr` field is sometimes missing.

Since this seems to be a bit of whack-a-mole: Is there any specification on how these metadata JSONs look like, and which fields may be missing? If not, can we find the source code that generates it?